### PR TITLE
Make forms, functions and signals files splitable.

### DIFF
--- a/djangofloor/tasks.py
+++ b/djangofloor/tasks.py
@@ -315,10 +315,10 @@ def import_signals_and_functions():
         package_dir = app_config.path
         for module_name in ("signals", "forms", "functions"):
             if os.path.isfile(os.path.join(package_dir, "%s.py" % module_name)):
-                try_import(f"{app}.{module_name}")
+                try_import("%s.%s" % (app, module_name))
             elif os.path.isdir(os.path.join(package_dir, module_name)):
                 for f in os.listdir(package_dir):
-                    try_import(f"{app}.{module_name}.{f}")
+                    try_import("%s.%s.%s" % (app, module_name, f))
     logger.debug(
         "Found signals: %s"
         % ", ".join(["%s (%d)" % (k, len(v)) for (k, v) in REGISTERED_SIGNALS.items()])

--- a/djangofloor/tasks.py
+++ b/djangofloor/tasks.py
@@ -301,6 +301,7 @@ def import_signals_and_functions():
     def try_import(module):
         try:
             import_module(module)
+            print(module)
         except ImportError as e:
             if package_dir and os.path.isfile(
                 os.path.join(package_dir, "%s.py" % module_name)
@@ -318,6 +319,7 @@ def import_signals_and_functions():
                 try_import("%s.%s" % (app, module_name))
             elif os.path.isdir(os.path.join(package_dir, module_name)):
                 for f in os.listdir(os.path.join(package_dir, module_name)):
+                    f = os.path.splitext(f)[0]
                     try_import("%s.%s.%s" % (app, module_name, f))
     logger.debug(
         "Found signals: %s"

--- a/djangofloor/tasks.py
+++ b/djangofloor/tasks.py
@@ -317,7 +317,7 @@ def import_signals_and_functions():
             if os.path.isfile(os.path.join(package_dir, "%s.py" % module_name)):
                 try_import("%s.%s" % (app, module_name))
             elif os.path.isdir(os.path.join(package_dir, module_name)):
-                for f in os.listdir(package_dir):
+                for f in os.listdir(os.path.join(package_dir, module_name)):
                     try_import("%s.%s.%s" % (app, module_name, f))
     logger.debug(
         "Found signals: %s"

--- a/djangofloor/tasks.py
+++ b/djangofloor/tasks.py
@@ -301,7 +301,6 @@ def import_signals_and_functions():
     def try_import(module):
         try:
             import_module(module)
-            print(module)
         except ImportError as e:
             if package_dir and os.path.isfile(
                 os.path.join(package_dir, "%s.py" % module_name)


### PR DESCRIPTION
In order to make big files splitable for readability into a directory named after the
file type, the `import_signals_and_functions` function now check if the
module `{forms|functions|signals}` is a file or a directory.
If the module is a file, it is imported
If the module is a directory, all files in the directory are imported.

The function `import_mod` has been created to avoid `try ... except`
redundancy.